### PR TITLE
fix: ajeitando o notebook 1

### DIFF
--- a/1. Começando com o Python.ipynb
+++ b/1. Começando com o Python.ipynb
@@ -136,6 +136,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_01.py # windows\""
    ]
@@ -162,6 +169,13 @@
    "source": [
     ">Atribua um número (sem as aspas) à variável 'name' e print essa variável"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -384,8 +398,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Selecionar o último caractere da string s"
+    "> Selecione o último caractere da string s"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -442,6 +463,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_07.py # windows"
    ]
@@ -482,6 +510,13 @@
    "source": [
     "> Checando se s não contém 'I' (i maiúsculo)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -544,6 +579,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_09.py # windows"
    ]
@@ -564,6 +606,13 @@
     "**Subtração:**\n",
     "> Tente subtrair dois números."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -591,6 +640,13 @@
     "O sinal de multiplicação é: *.  \n",
     ">Tente multiplicar dois números."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -625,6 +681,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_12.py # windows"
    ]
@@ -650,6 +713,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_13.py # windows"
    ]
@@ -669,6 +739,13 @@
    "source": [
     ">Tente a potência de um inteiro escrita como um float (ex: 12.0)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -710,6 +787,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_15.py # windows"
    ]
@@ -735,6 +819,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_16.py # windows"
    ]
@@ -754,6 +845,13 @@
    "source": [
     ">Divida 19 por 5"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -793,6 +891,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_18.py # windows"
    ]
@@ -819,6 +924,13 @@
    "source": [
     ">Calcule 19 módulo 5"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -935,6 +1047,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !cat solutions/01_20.py # mac/linux"
    ]
@@ -960,6 +1079,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_21.py # windows"
    ]
@@ -972,13 +1098,6 @@
    "source": [
     "# !cat solutions/01_21.py #mac/linux"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -996,6 +1115,13 @@
     "\n",
     ">Verifique se o comprimento do seu nome é maior que 5 e o comprimento do nome do seu mentor é menor que 7."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1064,6 +1190,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_23.py # windows"
    ]
@@ -1098,23 +1231,25 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# !type solutions\\\\01_24.py # windows"
+    "# !cat solutions/01_24.py # mac, linux"
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "# !cat solutions/01_24.py # mac, linux"
-  },
-  {
    "metadata": {},
-   "cell_type": "code",
    "outputs": [],
-   "execution_count": null,
-   "source": "# !type solutions\\01_24.py # windows"
+   "source": [
+    "# !type solutions\\01_24.py # windows"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1135,9 +1270,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# !type solutions\\\\01_25.py # windows"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1146,6 +1279,15 @@
    "outputs": [],
    "source": [
     "# !cat solutions/01_25.py #mac/linux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\\\01_25.py # windows"
    ]
   },
   {
@@ -1167,18 +1309,11 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "# !cat solutions/01_25.py # mac, linux"
-  },
-  {
    "metadata": {},
-   "cell_type": "code",
    "outputs": [],
-   "execution_count": null,
-   "source": "# !type solutions\\01_25.py # windows"
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1186,7 +1321,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !cat solutions/01_26.py"
+    "# !cat solutions/01_26.py # mac, linux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\01_26.py # windows"
    ]
   },
   {
@@ -1220,9 +1364,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# !type solutions\\\\01_27.py # windows"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1231,6 +1373,15 @@
    "outputs": [],
    "source": [
     "# !cat solutions/01_27.py #mac/linux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\\\01_27.py # windows"
    ]
   },
   {
@@ -1319,9 +1470,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# !type solutions\\\\01_28.py # windows"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1330,6 +1479,15 @@
    "outputs": [],
    "source": [
     "# !cat solutions/01_28.py #mac/linux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\\\01_28.py # windows"
    ]
   },
   {
@@ -1344,9 +1502,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# !type solutions\\\\01_29.py # windows"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1358,13 +1514,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\\\01_29.py # windows"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
     "\n",
     "<div class=\"alert alert-block alert-warning\" style=\"padding: 0px; padding-left: 20px; padding-top: 5px;\"><h2 style=\"color: #301E40\">\n",
-    "Funções\n",
+    "Funções Nativas\n",
     "</h2><br>\n",
     "</div>"
    ]
@@ -1391,9 +1556,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# !type solutions\\\\01_30.py # windows"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1402,6 +1565,15 @@
    "outputs": [],
    "source": [
     "# !cat solutions/01_30.py #mac/linux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\\\01_30.py # windows"
    ]
   },
   {
@@ -1419,6 +1591,13 @@
    "source": [
     "snakes = \"🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍🐍\""
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1450,9 +1629,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# !type solutions\\\\01_32.py # windows"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1461,6 +1638,15 @@
    "outputs": [],
    "source": [
     "# !cat solutions/01_32.py #mac/linux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\\\01_32.py # windows"
    ]
   },
   {
@@ -1475,9 +1661,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# !type solutions\\\\01_32.py # windows"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1486,6 +1670,15 @@
    "outputs": [],
    "source": [
     "# !cat solutions/01_33.py #mac/linux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\\\01_32.py # windows"
    ]
   },
   {
@@ -1500,9 +1693,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# !type solutions\\\\01_34.py # windows"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1514,11 +1705,27 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\\\01_34.py # windows"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     ">Arredonde o número 123.45 para 1 casa decimal."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1574,6 +1781,13 @@
    "source": [
     ">Usando o método append, adicione 'Aloha' à lista list_greeting."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1643,6 +1857,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# !type solutions\\\\01_37.py # windows"
    ]
@@ -1679,7 +1900,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !cat solutions/01_38.py"
+    "# !cat solutions/01_38.py # mac, linux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !type solutions\\01_38.py # windows"
    ]
   },
   {

--- a/1. Começando com o Python.ipynb
+++ b/1. Começando com o Python.ipynb
@@ -354,13 +354,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![image.png](attachment:image.png)"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/1. Começando com o Python.ipynb
+++ b/1. Começando com o Python.ipynb
@@ -651,7 +651,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !type solutions\\\\01_13.py # winodws"
+    "# !type solutions\\\\01_13.py # windows"
    ]
   },
   {
@@ -676,7 +676,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !type solutions\\\\01_14.py # winodws"
+    "# !type solutions\\\\01_14.py # windows"
    ]
   },
   {
@@ -826,7 +826,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !type solutions\\\\01_19.py # winodws"
+    "# !type solutions\\\\01_19.py # windows"
    ]
   },
   {
@@ -1114,7 +1114,7 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "# !type solutions\\01_24.py # winodws"
+   "source": "# !type solutions\\01_24.py # windows"
   },
   {
    "cell_type": "markdown",
@@ -1178,7 +1178,7 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "# !type solutions\\01_25.py # winodws"
+   "source": "# !type solutions\\01_25.py # windows"
   },
   {
    "cell_type": "code",

--- a/1. Começando com o Python.ipynb
+++ b/1. Começando com o Python.ipynb
@@ -1110,7 +1110,9 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "code",
+   "outputs": [],
    "execution_count": null,
    "source": "# !cat solutions/01_24.py # mac, linux"
   },
@@ -1172,7 +1174,9 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "code",
+   "outputs": [],
    "execution_count": null,
    "source": "# !cat solutions/01_25.py # mac, linux"
   },


### PR DESCRIPTION
esse PR:
- torna o notebook válido novamente
    - adicionando campos faltantes (`metadata` e `outputs`) > issue #37 
    - removendo imagem inexistente de uma célula > issue #31 
- conserta erros de digitação de `winodws` para `windows`
- com base no notebook 1 disponível no repositório oficial:
    - adiciona células vazias de solução (do usuário)
    - inverte ordem as células de execução da solução (as de linux/mac vêm antes das de windows)