### PR TITLE
fix: notebook 1 + traducao das solucoes

### DIFF
--- a/1. Começando com o Python.ipynb
+++ b/1. Começando com o Python.ipynb
@@ -166,7 +166,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": ">Atribua um número (sem as aspas) à variável 'name' e print essa variável."
+   "source": [
+    ">Atribua um número (sem as aspas) à variável 'name' e print essa variável."
+   ]
   },
   {
    "cell_type": "code",
@@ -362,10 +364,7 @@
     "\n",
     "**!!! Assim como aniversários, o Python começa a contar a partir de 0! (Ele é \"indexado a partir de zero\")** \n",
     "\n",
-
-
     "(Se você estiver interessada no motivo, aqui está uma [carta de Dijkstra](https://www.cs.utexas.edu/users/EWD/transcriptions/EWD08xx/EWD831.html) about it.)"
-
    ]
   },
   {
@@ -1071,7 +1070,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": ">Verifique se o tamanho do seu nome é maior do que 8 caracteres."
+   "source": [
+    ">Verifique se o tamanho do seu nome é maior do que 8 caracteres."
+   ]
   },
   {
    "cell_type": "code",
@@ -1163,26 +1164,12 @@
   },
   {
    "cell_type": "code",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-04-05T11:48:48.462908Z",
-     "start_time": "2026-04-05T11:48:48.311909Z"
-    }
-   },
-   "source": "lista_de_cumprimentos = ['Olá', 'Oie', 10, 'Hello', 'Bonjour', 'Ciao', False]",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Olá'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 7
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lista_de_cumprimentos = ['Hallo', 'Bonjour', 10, 'Hello', 'Ciao', False]"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1216,15 +1203,12 @@
   },
   {
    "cell_type": "code",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-04-05T11:48:58.828454Z",
-     "start_time": "2026-04-05T11:48:58.815689Z"
-    }
-   },
-   "source": "# !cat solutions/01_23.py #mac/linux",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
-   "execution_count": 8
+   "source": [
+    "# !cat solutions/01_23.py #mac/linux"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1244,7 +1228,6 @@
   },
   {
    "cell_type": "code",
-
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -1267,51 +1250,6 @@
    "source": [
     "# !type solutions\\01_24.py # windows"
    ]
-
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-04-05T11:56:25.438278Z",
-     "start_time": "2026-04-05T11:56:25.408941Z"
-    }
-   },
-   "source": [
-    "# !type solutions\\\\01_24.py # windows"
-   ],
-   "outputs": [],
-   "execution_count": 14
-  },
-  {
-   "cell_type": "code",
-   "source": "!cat solutions/01_24.py # mac, linux",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-04-05T11:56:26.304958Z",
-     "start_time": "2026-04-05T11:56:26.151964Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "lista_de_cumprimento[3:]\r\n"
-     ]
-    }
-   ],
-   "execution_count": 15
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-04-05T11:56:27.261059Z",
-     "start_time": "2026-04-05T11:56:27.257244Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "# !type solutions\\01_24.py # winodws",
-   "outputs": [],
-   "execution_count": 16
-
   },
   {
    "cell_type": "markdown",
@@ -1329,44 +1267,19 @@
   },
   {
    "cell_type": "code",
-
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": []
-
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-04-05T11:50:31.810135Z",
-     "start_time": "2026-04-05T11:50:31.804949Z"
-    }
-   },
-   "source": [
-    "# !type solutions\\\\01_25.py # windows"
-   ],
-   "outputs": [],
-   "execution_count": 12
-
   },
   {
    "cell_type": "code",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-04-05T11:50:35.549531Z",
-     "start_time": "2026-04-05T11:50:35.409940Z"
-    }
-   },
-   "source": "!cat solutions/01_25.py #mac/linux",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "list_greeting[:4]"
-     ]
-    }
-   ],
-   "execution_count": 13
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !cat solutions/01_25.py #mac/linux"
+   ]
   },
   {
    "cell_type": "code",
@@ -1398,14 +1311,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-
-
-   "source": "# !cat solutions/01_25.py # mac, linux",
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1434,7 +1339,7 @@
    "source": [
     "**Podemos atualizar uma lista reatribuindo um valor selecionado usando uma fatia.**\n",
     "\n",
-    "Por exemplo, podemos substituir False por 'Ave' em list_greeting."
+    "Por exemplo, podemos substituir False por 'Ave' em lista_de_cumprimentos."
    ]
   },
   {
@@ -1443,15 +1348,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "list_greeting[-1] = 'Ave'\n",
-    "print(list_greeting)"
+    "lista_de_cumprimentos[-1] = 'Ave'\n",
+    "print(lista_de_cumprimentos)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    ">Substitua 10 por \"Hola\" em list_greetings e, em seguida, print list_greeting."
+    ">Substitua 10 por \"Hola\" em lista_de_cumprimentos e, em seguida, print lista_de_cumprimentos."
    ]
   },
   {
@@ -1557,7 +1462,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    ">Verifique se `10` está em `list_greeting`."
+    ">Verifique se `10` está em `lista_de_cumprimentos`."
    ]
   },
   {
@@ -1589,7 +1494,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    ">Verifique se 'Ole' não está em list_greeting."
+    ">Verifique se 'Ole' não está em lista_de_cumprimentos."
    ]
   },
   {
@@ -1716,7 +1621,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    ">Calcule o tamanho de list_greeting."
+    ">Calcule o tamanho de lista_de_cumprimentos."
    ]
   },
   {
@@ -1874,7 +1779,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    ">Usando o método append, adicione 'Aloha' à lista list_greeting."
+    ">Usando o método append, adicione 'Aloha' à lista lista_de_cumprimentos."
    ]
   },
   {
@@ -2016,7 +1921,7 @@
     "# 🎉 Parabéns, você terminou o Notebook 1! 🎉\n",
     "Faça uma pausa merecida, prepare uma bebida relaxante de sua preferência ou coma um lanche. Quem sabe você não compartilha uma foto do seu lanche/bebida no canal #random? Adoramos ver fotos de todos os participantes ao redor do mundo. ☕️\n",
     "\n",
-    "![](https://media0.giphy.com/media/3otPoS81loriI9sO8o/200.gif)"
+    "![](https://media0.giphy.com/media/3otPoS81loriI9sO8o/200.gif)\n"
    ]
   }
  ],

--- a/solutions/01_03.py
+++ b/solutions/01_03.py
@@ -1,1 +1,1 @@
-"Ela disse: 'Eu estou curtindo esse workshop'"
+"Ela disse: 'Eu estou gostando desse workshop'"

--- a/solutions/01_03.py
+++ b/solutions/01_03.py
@@ -1,1 +1,1 @@
-"I'm enjoying this workshop!"
+"Ela disse: 'Eu estou curtindo esse workshop'"

--- a/solutions/01_04.py
+++ b/solutions/01_04.py
@@ -1,1 +1,1 @@
-'I'm enjoying this workshop!'
+'Ela disse: 'Eu estou curtindo esse workshop''

--- a/solutions/01_04.py
+++ b/solutions/01_04.py
@@ -1,1 +1,1 @@
-'Ela disse: 'Eu estou curtindo esse workshop''
+'Ela disse: 'Eu estou gostando desse workshop''

--- a/solutions/01_05.py
+++ b/solutions/01_05.py
@@ -1,1 +1,1 @@
-'Ela disse: \'Eu estou curtindo esse workshop\''
+'Ela disse: \'Eu estou gostando desse workshop\''

--- a/solutions/01_05.py
+++ b/solutions/01_05.py
@@ -1,1 +1,1 @@
-'I\'m enjoying this workshop!'
+'Ela disse: \'Eu estou curtindo esse workshop\''

--- a/solutions/01_24.py
+++ b/solutions/01_24.py
@@ -1,1 +1,1 @@
-lista_de_cumprimento[3:]
+lista_de_cumprimentos[3:]

--- a/solutions/01_32.py
+++ b/solutions/01_32.py
@@ -1,1 +1,1 @@
-len(list_greeting)
+len(lista_de_cumprimentos)

--- a/solutions/01_36.py
+++ b/solutions/01_36.py
@@ -1,1 +1,1 @@
-list_greeting.append("Aloha")
+lista_de_cumprimentos.append("Aloha")

--- a/solutions/02_23.py
+++ b/solutions/02_23.py
@@ -1,1 +1,1 @@
-print(f"number of rows of df_2: {df_2.shape[0]}")
+print(f"número de linhas de df_2: {df_2.shape[0]}")

--- a/solutions/02_25.py
+++ b/solutions/02_25.py
@@ -1,1 +1,1 @@
-print(f"number of rows of df_3: {df_3.shape[0]}")
+print(f"número de linhas de df_3: {df_3.shape[0]}")

--- a/solutions/05_10.py
+++ b/solutions/05_10.py
@@ -1,5 +1,5 @@
 df = df.reset_index()
 df.index
 
-# We could also have done the following when concatenating:
+# Também poderíamos ter feito o seguinte ao concatenar:
 # df = pd.concat(frames, ignore_index=True)

--- a/solutions/05_38.py
+++ b/solutions/05_38.py
@@ -1,5 +1,5 @@
 df = df.drop("Country", axis=1)
 
-# N.B. You can only run this cell once! If you try run it again, it will throw an error!
-#      Why? Because if you drop the Country column, it will be removed...so you can't
-#      drop it a second time as the column isn't there to drop!
+# Obs.: você só pode executar esta célula uma vez! Se tentar executá-la novamente, ocorrerá um erro!
+#       Por quê? Porque, se a coluna Country for removida, ela não estará mais no dataframe...
+#       então não dá para removê-la uma segunda vez, já que a coluna não está mais lá!


### PR DESCRIPTION
## Resumo

Dois fixes empacotados juntos porque o segundo dependia do primeiro:

### 1. Notebook 1 estava com JSON quebrado

Origem: a resolução de merge no commit \`9715a28 correcao de variaveis notebook 1\` removeu os marcadores \`<<<<<<<<\`/\`========\`/\`>>>>>>>>\` mas deixou ambas as versões dos cells em conflito lado a lado — gerando células duplicadas (em torno de \`01_24.py\` e \`01_25.py\`) com metadata de execução polução do Jupyter, e quebrando a estrutura JSON.

Fix: restaurei o notebook ao último estado válido (\`cd9ade7\`) e reapliquei via script as mudanças semânticas do commit \`1af4e6e correcao minima de genero & solucoes\` que ainda fazem sentido:
- Correções de gênero (interessado → interessada, programador → programador(a))
- Modernização ("não hesite em buscar coisas no Google" → "busque coisas novas no Google ou explore usando IA")
- Remoção da frase em inglês duplicada sobre Booleans
- Clarificação ("maior do que 8" → "maior do que 8 caracteres")
- Completa o rename \`list_greeting\` → \`lista_de_cumprimentos\` (estava aplicado só na definição)
- Corrige typo \`lista_de_cumprimentoss\` → \`lista_de_cumprimentos\`

Notebook agora parsea limpo (223 células, vs. broken antes).

### 2. Traduções de solutions

Identifiquei ~10 arquivos em \`solutions/\` que ainda continham conteúdo em inglês inconsistente com a tradução dos notebooks. Mantive os outros 116 arquivos intactos (pure code, column names de CSV, ou já em PT).

| Arquivo | Mudança |
|---|---|
| \`01_03/04/05.py\` | \`"I'm enjoying..."\` → \`"Ela disse: 'Eu estou curtindo...'"\` (preserva o SyntaxError intencional em 01_04) |
| \`01_24.py\` | typo \`lista_de_cumprimento\` → \`lista_de_cumprimentos\` |
| \`01_32/36.py\` | rename \`list_greeting\` → \`lista_de_cumprimentos\` |
| \`02_23/25.py\` | f-string \`"number of rows of df_X"\` → \`"número de linhas de df_X"\` |
| \`05_10.py\` | comentário em inglês traduzido |
| \`05_38.py\` | comentário em inglês traduzido (3 linhas) |

## Test plan

- [x] Abrir notebook 1 no Jupyter e verificar que carrega e renderiza
- [x] Confirmar que executar células ao redor de \`01_24.py\` e \`01_25.py\` funciona normalmente
- [x] Verificar que \`!cat solutions/01_03.py\` mostra a string PT
- [ ] Após merge: rodar \`sync.sh\` no \`HumbleData/online_workshop_ptbr\` para atualizar o site em produção
